### PR TITLE
1948 ext

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -1403,6 +1403,10 @@
 #define SCHEDULER_MAX_SCHEDULES     10          // Max schedules alowed
 #endif
 
+#ifndef SCHEDULER_RESTORE_LAST_SCHEDULE
+#define SCHEDULER_RESTORE_LAST_SCHEDULE      0  // Restore the last schedule state on the device boot
+#endif
+
 // -----------------------------------------------------------------------------
 // NTP
 // -----------------------------------------------------------------------------

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -34,7 +34,6 @@ typedef struct {
     unsigned long change_time;  // Scheduled time to change
     bool report;                // Whether to report to own topic
     bool group_report;          // Whether to report to group topic
-    unsigned char restore_last_schedule;  // Boolean, Restore to last schedule or not
 
     // Helping objects
 
@@ -657,7 +656,6 @@ void _relayConfigure() {
             //set to high to block short opening of relay
             digitalWrite(_relays[i].pin, HIGH);
         }
-        _relays[i].restore_last_schedule = getSetting("relayLastschedule", i, 1).toInt();
     }
 
     #if MQTT_SUPPORT
@@ -733,7 +731,10 @@ void _relayWebSocketSendRelays(JsonObject& root) {
     JsonArray& boot = relays.createNestedArray("boot");
     JsonArray& pulse = relays.createNestedArray("pulse");
     JsonArray& pulse_time = relays.createNestedArray("pulse_time");
-    JsonArray& restore_last_schedule = relays.createNestedArray("restore_last_schedule");
+
+    #if SCHEDULER_SUPPORT
+        JsonArray& restore_last_schedule = relays.createNestedArray("restore_last_schedule");
+    #endif
 
     #if MQTT_SUPPORT
         JsonArray& group = relays.createNestedArray("group");
@@ -750,7 +751,10 @@ void _relayWebSocketSendRelays(JsonObject& root) {
 
         pulse.add(_relays[i].pulse);
         pulse_time.add(_relays[i].pulse_ms / 1000.0);
-        restore_last_schedule.add(_relays[i].restore_last_schedule);
+
+        #if SCHEDULER_SUPPORT
+            restore_last_schedule.add(getSetting("relayLastSchedule", i, 0).toInt() == 1);
+        #endif
 
         #if MQTT_SUPPORT
             group.add(getSetting("mqttGroup", i, ""));

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -753,7 +753,7 @@ void _relayWebSocketSendRelays(JsonObject& root) {
         pulse_time.add(_relays[i].pulse_ms / 1000.0);
 
         #if SCHEDULER_SUPPORT
-            restore_last_schedule.add(getSetting("relayLastSchedule", i, 0).toInt() == 1);
+            restore_last_schedule.add(getSetting("relayLastSchedule", i, SCHEDULER_RESTORE_LAST_SCHEDULE).toInt() == 1);
         #endif
 
         #if MQTT_SUPPORT

--- a/code/espurna/scheduler.ino
+++ b/code/espurna/scheduler.ino
@@ -11,7 +11,7 @@ Adapted by Xose Pérez <xose dot perez at gmail dot com>
 
 #include <TimeLib.h>
 
-int RestoredLastSchedules = 0;
+int _sch_restore = 0;
 
 // -----------------------------------------------------------------------------
 
@@ -246,12 +246,12 @@ void _schLoop() {
     // Check time has been sync'ed
     if (!ntpSynced()) return;
 
-    if (RestoredLastSchedules == 0) {
+    if (_sch_restore == 0) {
         for (int i = 0; i < _relays.size(); i++){
-          if (getSetting("relayLastschedule", i, 1).toInt() == 1)
+            if (getSetting("relayLastSchedule", i, 0).toInt() == 1)
                 _schCheck(i, 0);
         }
-        RestoredLastSchedules = 1;
+        _sch_restore = 1;
     }
 
     // Check schedules every minute at hh:mm:00

--- a/code/espurna/scheduler.ino
+++ b/code/espurna/scheduler.ino
@@ -138,13 +138,36 @@ int _schMinutesLeft(time_t t, unsigned char schedule_hour, unsigned char schedul
     return (schedule_hour - now_hour) * 60 + schedule_minute - now_minute;
 }
 
-// if passed values are -1,-1 than its a regular check
+void _schAction(int sch_id, int sch_action, int sch_switch) {
+    unsigned char sch_type = getSetting("schType", sch_id, SCHEDULER_TYPE_SWITCH).toInt();
+
+    if (SCHEDULER_TYPE_SWITCH == sch_type) {
+        DEBUG_MSG_P(PSTR("[SCH] Switching switch %d to %d\n"), sch_switch, sch_action);
+        if (sch_action == 2) {
+            relayToggle(sch_switch);
+        } else {
+            relayStatus(sch_switch, sch_action);
+        }
+    }
+
+    #if LIGHT_PROVIDER != LIGHT_PROVIDER_NONE
+        if (SCHEDULER_TYPE_DIM == sch_type) {
+            DEBUG_MSG_P(PSTR("[SCH] Set channel %d value to %d\n"), sch_switch, sch_action);
+            lightChannel(sch_switch, sch_action);
+            lightUpdate(true, true);
+        }
+    #endif
+}
+
+// If daybefore and relay is -1, check with current timestamp
+// Otherwise, modify it by moving 'daybefore' days back and only use the 'relay' id
 void _schCheck(int relay, int daybefore) {
 
     time_t local_time = now();
     time_t utc_time = ntpLocal2UTC(local_time);
     int minimum_restore_time = -1440;
     int saved_action = -1;
+    int saved_sch = -1;
 
     // Check schedules
     for (unsigned char i = 0; i < SCHEDULER_MAX_SCHEDULES; i++) {
@@ -177,31 +200,12 @@ void _schCheck(int relay, int daybefore) {
             if (sch_switch == relay && sch_action != 2 && minutes_to_trigger < 0 && minutes_to_trigger > minimum_restore_time) {
                 minimum_restore_time = minutes_to_trigger;
                 saved_action = sch_action;
+                saved_sch = i;
             }
 
             if (minutes_to_trigger == 0 && relay == -1) {
 
-                unsigned char sch_type = getSetting("schType", i, SCHEDULER_TYPE_SWITCH).toInt();
-
-                if (SCHEDULER_TYPE_SWITCH == sch_type) {
-                    int sch_action = getSetting("schAction", i, 0).toInt();
-                    DEBUG_MSG_P(PSTR("[SCH] Switching switch %d to %d\n"), sch_switch, sch_action);
-                    if (sch_action == 2) {
-                        relayToggle(sch_switch);
-                    } else {
-                        relayStatus(sch_switch, sch_action);
-                    }
-                }
-
-                #if LIGHT_PROVIDER != LIGHT_PROVIDER_NONE
-                    if (SCHEDULER_TYPE_DIM == sch_type) {
-                        int sch_brightness = getSetting("schAction", i, -1).toInt();
-                        DEBUG_MSG_P(PSTR("[SCH] Set channel %d value to %d\n"), sch_switch, sch_brightness);
-                        lightChannel(sch_switch, sch_brightness);
-                        lightUpdate(true, true);
-                    }
-                #endif
-
+                _schAction(i, sch_action, sch_switch);
                 DEBUG_MSG_P(PSTR("[SCH] Schedule #%d TRIGGERED!!\n"), i);
 
             // Show minutes to trigger every 15 minutes
@@ -231,8 +235,9 @@ void _schCheck(int relay, int daybefore) {
       return;
     }
 
-    if (minimum_restore_time != -1440 && saved_action != -1)
-      relayStatus(relay, saved_action);
+    if (minimum_restore_time != -1440 && saved_action != -1 && saved_sch != -1) {
+        _schAction(saved_sch, saved_action, relay);
+    }
 
 }
 

--- a/code/espurna/scheduler.ino
+++ b/code/espurna/scheduler.ino
@@ -248,7 +248,7 @@ void _schLoop() {
 
     if (_sch_restore == 0) {
         for (int i = 0; i < _relays.size(); i++){
-            if (getSetting("relayLastSchedule", i, 0).toInt() == 1)
+            if (getSetting("relayLastSchedule", i, SCHEDULER_RESTORE_LAST_SCHEDULE).toInt() == 1)
                 _schCheck(i, 0);
         }
         _sch_restore = 1;

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -1890,7 +1890,7 @@
                 <div class="pure-u-1 pure-u-lg-1-4"><label>Pulse time (s)</label></div>
                 <div class="pure-u-1 pure-u-lg-1-4"><input name="relayTime" class="pure-u-1" type="number" min="0" step="0.1" max="3600" /></div>
             </div>
-            <div class="p-g">
+            <div class="p-g module module-sch">
                 <div class="p-u-1 p-u-lg-1-4"><label>Restore last schedule</label></div>
                 <div><input name="relayLastschedule" type="checkbox" /></div>
             </div>


### PR DESCRIPTION
Follow-up for #1948, since suggesting these changes in a review ui would be much slower.

Looking at it again, it sure is easier to handle via relays. However, maybe we can split up action like this? This way it is not limited to switch on / off actions (I hope I haven't missed anything though, because I have not tested this yet)
`sch_action != 2` would avoid toggle action but now it has a funny issue with brightness==2, should there be another check?

I also hid the settings under SCHEDULER_SUPPORT and removed struct member (we only ever need it once or in webui, which we can just get from settings)

This also disables it by default